### PR TITLE
MAINT: avoid tracking of TeX generated files

### DIFF
--- a/src/doc/.gitignore
+++ b/src/doc/.gitignore
@@ -1,0 +1,5 @@
+*.idx
+*.aux
+*.toc
+*.log
+*.out


### PR DESCRIPTION
To keep a clean repository after generating the docs.