### PR TITLE
commit on jsoncpp master breaks Optizelle 

### DIFF
--- a/src/cpp/optizelle/json.cpp
+++ b/src/cpp/optizelle/json.cpp
@@ -190,7 +190,7 @@ namespace Optizelle {
                 typename RestartPackage <Natural>::t & nats
             ) {
                 // Loop over all the names in the root
-                for(Json::ValueIterator itr=root[vs].begin();
+                for(Json::ValueConstIterator itr=root[vs].begin();
                     itr!=root[vs].end();
                     itr++
                 ){
@@ -209,7 +209,7 @@ namespace Optizelle {
                 typename RestartPackage <std::string>::t & params 
             ) {
                 // Loop over all the names in the root
-                for(Json::ValueIterator itr=root[vs].begin();
+                for(Json::ValueConstIterator itr=root[vs].begin();
                     itr!=root[vs].end();
                     itr++
                 ){

--- a/src/cpp/optizelle/json.h
+++ b/src/cpp/optizelle/json.h
@@ -286,7 +286,7 @@ namespace Optizelle {
                 Json::StyledWriter writer;
 
                 // Loop over all the names in the root
-                for(Json::ValueIterator itr=root[vs].begin();
+                for(Json::ValueConstIterator itr=root[vs].begin();
                     itr!=root[vs].end();
                     itr++
                 ){
@@ -307,7 +307,7 @@ namespace Optizelle {
                 typename RestartPackage <Real>::t & reals
             ) {
                 // Loop over all the names in the root
-                for(Json::ValueIterator itr=root[vs].begin();
+                for(Json::ValueConstIterator itr=root[vs].begin();
                     itr!=root[vs].end();
                     itr++
                 ){


### PR DESCRIPTION
jsoncpp commit https://github.com/open-source-parsers/jsoncpp/commit/c8a8cfcd4b09ee762a129478f75d3f95f50265c9 goes from
_ValueConstIterator can convert to ValueIterator_ to _ValueIterator can convert to ValueConstIterator_.
This breaks Optizelle which relies on the old conversion.
ValueConstIterator is backwards compatible with older jsoncpp versions, so this change should not break anything for those with older jsoncpp versions.