### PR TITLE
fixed crash caused by decrementing unsigned variable below 0

### DIFF
--- a/src/cpp/optizelle/linalg.h
+++ b/src/cpp/optizelle/linalg.h
@@ -2523,8 +2523,8 @@ namespace Optizelle {
                 // quit
                 else {
                     vs.pop_back();
-                    iter--;
-                    i--;
+                    if ( iter > 0 ) { iter--; }
+                    if ( i    > 0 ) { i--; }
                     nan_detected=true;
                     // Note, norm_r will not be correct on the next iteration
                 }


### PR DESCRIPTION
Hello,

I have been getting consistent crashes and after some debugging I realized the problem was an iterator / index being decremented below 0. I am not really sure if the (dumb) fix I did is actually correct in the context of what the function should do, however it solved the crash for me.