### PR TITLE
Weak linking python libs on macOS

### DIFF
--- a/src/python/Optizelle/CMakeLists.txt
+++ b/src/python/Optizelle/CMakeLists.txt
@@ -9,8 +9,7 @@ include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(${OPTIZELLE_PYTHON_INCLUDE_DIRS})
 add_library(optizelle_python SHARED ${optizelle_python_srcs})
 target_link_libraries(optizelle_python
-    optizelle_shared
-    ${PYTHON_LIBRARIES})
+    optizelle_shared)
 set_target_properties(optizelle_python PROPERTIES OUTPUT_NAME Utility)
 set_target_properties(optizelle_python PROPERTIES PREFIX "")
 if(APPLE)
@@ -22,6 +21,9 @@ if(APPLE)
     set_target_properties(optizelle_python PROPERTIES INSTALL_RPATH "@loader_path/../../../../lib;@loader_path/../../thirdparty/lib")
 elseif(UNIX)
     set_target_properties(optizelle_python PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../../lib;\$ORIGIN/../../thirdparty/lib")
+endif()
+if(APPLE)
+	set_target_properties(optizelle_python PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 endif()
 
 # Copy in the rest of the Python files for the unit tests.  Otherwise, we

--- a/src/python/Optizelle/CMakeLists.txt
+++ b/src/python/Optizelle/CMakeLists.txt
@@ -8,8 +8,16 @@ set(optizelle_python_srcs "Utility.cpp")
 include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(${OPTIZELLE_PYTHON_INCLUDE_DIRS})
 add_library(optizelle_python SHARED ${optizelle_python_srcs})
-target_link_libraries(optizelle_python
-    optizelle_shared)
+
+if(APPLE)
+    target_link_libraries(optizelle_python
+        optizelle_shared)
+else()
+    target_link_libraries(optizelle_python
+        optizelle_shared
+        ${PYTHON_LIBRARIES})
+endif()
+
 set_target_properties(optizelle_python PROPERTIES OUTPUT_NAME Utility)
 set_target_properties(optizelle_python PROPERTIES PREFIX "")
 if(APPLE)


### PR DESCRIPTION
Without this, using any non system python, seems to cause a crash on
macOS saying: "PyThreadState_Get: no current thread"

See https://github.com/OptimoJoe/Optizelle/issues/62