### PR TITLE
Fix dependency finder - Could not find JsonCPP on macOS 15.15

### DIFF
--- a/src/cmake/Modules/FindJsonCpp.cmake
+++ b/src/cmake/Modules/FindJsonCpp.cmake
@@ -11,7 +11,7 @@ set(JSONCPP_INCLUDE_DIRS ${JSONCPP_INCLUDE_DIR} )
 
 # Find the library
 find_library(JSONCPP_LIBRARY
-    NAMES json libjson
+    NAMES json libjson jsoncpp
     HINTS ${PC_JSONCPP_LIBDIR} ${PC_JSONCPP_LIBRARY_DIRS} )
 set(JSONCPP_LIBRARIES ${JSONCPP_LIBRARY} )
 


### PR DESCRIPTION
###  Facts
- On macOS 15.15, `cmake` (3.17) fails to find `JsonCpp` library.
- JsonCpp installed with `hombrew` is indexed as `jsoncpp`. 


### Fix
- [x] Added `jsoncpp` to the list of possible names for the library.
- [x]  backward compatible.
- [x] isolated change, no side effects. 